### PR TITLE
Add fallback for `docker_binary` attribute

### DIFF
--- a/docker_stack_deploy/cli/deployer.py
+++ b/docker_stack_deploy/cli/deployer.py
@@ -8,6 +8,7 @@ import hashlib
 import subprocess
 import collections.abc as collections
 from copy import deepcopy
+from shutil import which
 
 VERBOSE: bool = (
     os.getenv("DOCKER_SWARM_DEPLOY_VERBOSE") == "1"
@@ -165,16 +166,6 @@ def find_all_stack_files(argv: List[str]) -> List[Tuple[int, str]]:
 
 def private_opener(path, flags):
     return os.open(path, flags, 0o600)
-
-if sys.version_info >= (3,3):
-    from shutil import which
-else:
-    def which(pgm):
-        path = os.getenv("PATH")
-        for p in path.split(os.path.pathsep):
-            p = os.path.join(p, pgm)
-            if os.path.exists(p) and os.access(p, os.X_OK):
-                return p
 
 
 def docker_stack_deploy() -> None:

--- a/docker_stack_deploy/cli/deployer.py
+++ b/docker_stack_deploy/cli/deployer.py
@@ -166,6 +166,16 @@ def find_all_stack_files(argv: List[str]) -> List[Tuple[int, str]]:
 def private_opener(path, flags):
     return os.open(path, flags, 0o600)
 
+if sys.version_info >= (3,3):
+    from shutil import which
+else:
+    def which(pgm):
+        path = os.getenv("PATH")
+        for p in path.split(os.path.pathsep):
+            p = os.path.join(p, pgm)
+            if os.path.exists(p) and os.access(p, os.X_OK):
+                return p
+
 
 def docker_stack_deploy() -> None:
     all_stack_files = find_all_stack_files(sys.argv)
@@ -235,6 +245,8 @@ def docker_stack_deploy() -> None:
             docker_binary = "/bin/docker"
         elif os.path.isfile("/usr/bin/docker"):
             docker_binary = "/usr/bin/docker"
+        else:
+            docker_binary = which("docker")
 
         new_cmd = [docker_binary, *forwarded_params]
         if VERBOSE:
@@ -278,6 +290,8 @@ Usage of docker stack deploy follows:"""
         docker_binary = "/bin/docker"
     elif os.path.isfile("/usr/bin/docker"):
         docker_binary = "/usr/bin/docker"
+    else:
+        docker_binary = which("docker")
     subprocess.check_call(
         [docker_binary, "stack", "deploy", "--help"],
         env={


### PR DESCRIPTION
It use `which` from `shutil` std package for Python 3.3 and later, we also define helper function called `which` for prior version.